### PR TITLE
fix: remove CUTOFF_DATE filter and fix workflow push race condition

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -61,5 +61,6 @@ jobs:
             echo "No changes — nothing to commit"
           else
             git commit -m "docs: rebuild site and update metadata [skip ci]"
+            git pull --rebase origin main
             git push
           fi

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -42,7 +42,6 @@ RESEARCH_DIR = DOCS_DIR / "research"
 TAGS_DIR = DOCS_DIR / "tags"
 THREADS_DIR = DOCS_DIR / "threads"
 
-CUTOFF_DATE = date(2026, 2, 28)
 GITHUB_BASE = "https://github.com/davidamitchell/Research/blob/main/Research/completed/"
 
 # Section names to extract, in display order
@@ -1086,12 +1085,11 @@ def get_findings_excerpt(item: dict, max_chars: int = 200) -> str:
 def load_items() -> tuple[list[dict], dict[str, int]]:
     """Load and filter all completed research items.
 
-    Returns (items, exclusion_stats) where exclusion_stats has keys
-    'meta_infra' and 'date' with counts of excluded files.
+    Returns (items, exclusion_stats) where exclusion_stats has key
+    'meta_infra' with count of excluded files.
     """
     items = []
     excl_meta = 0
-    excl_date = 0
     for path in sorted(COMPLETED_DIR.glob("*.md"), reverse=True):
         name = path.name
         if name.lower() == "readme.md":
@@ -1108,7 +1106,6 @@ def load_items() -> tuple[list[dict], dict[str, int]]:
             raise SystemExit(1) from exc
         added_raw = meta.get("added")
         if not added_raw:
-            excl_date += 1
             continue
         try:
             if isinstance(added_raw, str):
@@ -1116,10 +1113,6 @@ def load_items() -> tuple[list[dict], dict[str, int]]:
             else:
                 added = date(added_raw.year, added_raw.month, added_raw.day)
         except (ValueError, AttributeError):
-            excl_date += 1
-            continue
-        if added < CUTOFF_DATE:
-            excl_date += 1
             continue
         title = str(meta.get("title", path.stem))
         tags = normalise_tags(meta.get("tags", []))
@@ -1146,7 +1139,7 @@ def load_items() -> tuple[list[dict], dict[str, int]]:
             }
         )
     items.sort(key=lambda x: x["added"], reverse=True)
-    return items, {"meta_infra": excl_meta, "date": excl_date}
+    return items, {"meta_infra": excl_meta}
 
 
 def load_metadata() -> dict:
@@ -2144,8 +2137,7 @@ def main() -> None:
     items, excl_stats = load_items()
     print(f"  {len(items)} items loaded")
     print(
-        f"  {excl_stats['meta_infra'] + excl_stats['date']} items excluded"
-        f" (meta/infra: {excl_stats['meta_infra']}, date: {excl_stats['date']})"
+        f"  {excl_stats['meta_infra']} items excluded (meta/infra)"
     )
 
     # Singleton tag filtering
@@ -2260,8 +2252,7 @@ def main() -> None:
     print("\nBuild complete.")
     print(f"  {len(items)} items processed")
     print(
-        f"  {excl_stats['meta_infra'] + excl_stats['date']} items excluded"
-        f" (meta/infra: {excl_stats['meta_infra']}, date: {excl_stats['date']})"
+        f"  {excl_stats['meta_infra']} items excluded (meta/infra)"
     )
     print(f"  {pages_written} pages written")
     print(f"  {unique_tags} unique tags (after singleton filtering)")

--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -16,7 +16,7 @@ import datetime as _dt
 import json
 import re
 from collections import Counter
-from datetime import UTC, date
+from datetime import UTC
 from pathlib import Path
 
 import yaml
@@ -28,8 +28,6 @@ import yaml
 REPO_ROOT = Path(__file__).parent.parent
 COMPLETED_DIR = REPO_ROOT / "Research" / "completed"
 STATE_DIR = REPO_ROOT / "state"
-
-CUTOFF_DATE = date(2026, 2, 28)
 
 # ---------------------------------------------------------------------------
 # Stopwords
@@ -517,19 +515,6 @@ def main() -> None:
 
         text = path.read_text(encoding="utf-8")
         meta, body = parse_frontmatter(text)
-
-        added_raw = meta.get("added")
-        if not added_raw:
-            continue
-        try:
-            if isinstance(added_raw, str):
-                added = date.fromisoformat(added_raw)
-            else:
-                added = date(added_raw.year, added_raw.month, added_raw.day)
-        except (ValueError, AttributeError):
-            continue
-        if added < CUTOFF_DATE:
-            continue
 
         slug = slugify(path.stem)
 


### PR DESCRIPTION
- Remove CUTOFF_DATE (2026-02-28) from both build scripts so all
  completed research docs are included regardless of added date
- Add git pull --rebase origin main before git push in build_site.yml
  to fix race condition where consolidate_research.yml pushes first
  (it wins consistently as it has no pip install step), causing
  build_site.yml's git push to fail on a non-fast-forward ref

https://claude.ai/code/session_01Rd8orVEtUFHNPczLhMXNJh