### PR TITLE
fix: use <a id=> anchors in consolidate workflow (was <a name=>)

### DIFF
--- a/.github/workflows/consolidate_research.yml
+++ b/.github/workflows/consolidate_research.yml
@@ -103,7 +103,7 @@ jobs:
             ANCHOR=$(echo "$FILENAME" | tr '[:upper:]' '[:lower:]' | tr ' .' '--')
 
             # HTML anchor so TOC links resolve in rendered Markdown
-            echo "<a name=\"$ANCHOR\"></a>" >> "$OUTPUT_FILE"
+            echo "<a id=\"$ANCHOR\"></a>" >> "$OUTPUT_FILE"
             echo "" >> "$OUTPUT_FILE"
             echo "## $TITLE" >> "$OUTPUT_FILE"
             echo "" >> "$OUTPUT_FILE"


### PR DESCRIPTION
markdown-it-py does not pass <a name=""> through as raw HTML, so the
deprecated name= form would produce broken anchor targets after the next
Research_Master.md regeneration, silently breaking all 475 TOC fragment
links in research-master.html.  The test at test_build_site.py:328 already
asserts id= anchors must be present and name= anchors must be absent.

https://claude.ai/code/session_01TkGYctQXz6BUDMVzeksr4y