### PR TITLE
fix: raise timeout to 150m, scheduled cap to 4 items, dispatch options to 1-7

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -515,7 +515,7 @@ When executing the `research` skill or conducting a research item end-to-end:
 - Copilot reads `research-prompt.md`, picks the highest-priority backlog item, researches it, marks it as a draft, triggers the quality review workflow (and waits for it), then completes the item and commits it + a new `progress/` session log directly to `main`.
 - The outer `while` loop restarts Copilot for the next item until `max_items` is reached or the backlog is empty.
 
-**Automatic schedule:** Runs weekdays at 07:00 UTC, processes 3 items per day.
+**Automatic schedule:** Runs weekdays at 07:00 UTC, processes 4 items per day.
 
 **Manual trigger:**
 1. Go to the repository on GitHub
@@ -523,7 +523,7 @@ When executing the `research` skill or conducting a research item end-to-end:
 3. Click **"Research Loop"** in the left sidebar
 4. Click **"Run workflow"** → select `max_items` from the dropdown (default `1`) → click **"Run workflow"**
 
-**Safety controls:** The loop has multiple runaway-loop guards — see ADR-0004 for full details. Conservative defaults: max 1 item per manual run, max 3 per scheduled run, 90-minute job timeout, 10-iteration hard ceiling, 30-second inter-iteration sleep, abort after 2 consecutive Copilot failures.
+**Safety controls:** The loop has multiple runaway-loop guards — see ADR-0004 for full details. Conservative defaults: max 1 item per manual run, max 4 per scheduled run, 150-minute job timeout, 10-iteration hard ceiling, 30-second inter-iteration sleep, abort after 2 consecutive Copilot failures.
 
 **Tuning:** Edit `research-prompt.md` to adjust what Copilot looks for, how findings are structured, or which items to prioritise. The prompt is the only lever — no code changes needed.
 

--- a/.github/workflows/research-loop.yml
+++ b/.github/workflows/research-loop.yml
@@ -17,8 +17,8 @@ name: Research Loop
 #     fetch transcripts and metadata. Without this, YouTube fetches fail silently.
 #
 # Safety controls (see ADR-0004):
-#   - Job-level timeout: 90 minutes hard ceiling per run.
-#   - Per-run cap: scheduled runs process at most 3 items; dispatch default is 1.
+#   - Job-level timeout: 150 minutes hard ceiling per run.
+#   - Per-run cap: scheduled runs process at most 4 items; dispatch default is 1.
 #   - Absolute iteration ceiling: HARD_MAX_ITERATIONS (10).
 #   - Failure limit: 2 consecutive Copilot failures abort the run.
 #     Rate limit hits are NOT counted as failures -- they break the loop cleanly.
@@ -27,13 +27,13 @@ name: Research Loop
 #
 # Trigger options:
 #   1. Manual: Actions tab -> "Research Loop" -> Run workflow -> set max_items
-#   2. Scheduled: runs automatically on weekday mornings (processes 3 items)
+#   2. Scheduled: runs automatically on weekday mornings (processes 4 items)
 
 on:
   workflow_dispatch:
     inputs:
       max_items:
-        description: "Max items to process (1-5). Defaults to 1 for safety."
+        description: "Max items to process (1-7). Defaults to 1 for safety."
         required: false
         default: "1"
         type: choice
@@ -43,6 +43,8 @@ on:
           - "3"
           - "4"
           - "5"
+          - "6"
+          - "7"
 
   schedule:
     # Weekdays at 07:00 UTC -- runs after the skills sync (Monday 06:00 UTC)
@@ -58,8 +60,8 @@ jobs:
     name: Work research backlog
     runs-on: ubuntu-latest
 
-    # Hard ceiling: no single run may exceed 90 minutes regardless of backlog size.
-    timeout-minutes: 90
+    # Hard ceiling: no single run may exceed 150 minutes regardless of backlog size.
+    timeout-minutes: 150
 
     permissions:
       contents: write
@@ -115,7 +117,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             MAX_ITEMS="${{ inputs.max_items }}"
           else
-            MAX_ITEMS="3"
+            MAX_ITEMS="4"
           fi
 
           echo "Configuration: MAX_ITEMS=$MAX_ITEMS, HARD_MAX_ITERATIONS=$HARD_MAX_ITERATIONS, FAILURE_THRESHOLD=$FAILURE_THRESHOLD"

--- a/docs-adr/0004-autonomous-research-loop.md
+++ b/docs-adr/0004-autonomous-research-loop.md
@@ -35,18 +35,18 @@ Five independent safety controls are layered to stop runaway behaviour:
 
 | Control | Mechanism | Value |
 |---|---|---|
-| Job timeout | `timeout-minutes` on the GitHub Actions job | 90 minutes |
-| Per-run item cap | `MAX_ITEMS` from workflow input or schedule default | 1 (dispatch) / 3 (schedule) |
+| Job timeout | `timeout-minutes` on the GitHub Actions job | 150 minutes |
+| Per-run item cap | `MAX_ITEMS` from workflow input or schedule default | 1 (dispatch) / 4 (schedule) |
 | Hard iteration ceiling | `HARD_MAX_ITERATIONS` constant in the shell script | 10 |
 | Consecutive failure abort | `FAILURE_THRESHOLD` + `CONSECUTIVE_FAILURES` counter | 2 consecutive failures |
 | Inter-iteration sleep | `INTER_ITERATION_SLEEP` between loop iterations | 30 seconds |
 
 **Job timeout** is the hardest ceiling. GitHub Actions will kill the entire job after
-90 minutes regardless of what the shell script is doing. Even if every other control fails,
+150 minutes regardless of what the shell script is doing. Even if every other control fails,
 the job cannot run indefinitely.
 
 **Per-run item cap** limits expected throughput. The `max_items` input is a constrained
-dropdown (choices 1–5), removing the possibility of accidentally entering 0 or an
+dropdown (choices 1–7), removing the possibility of accidentally entering 0 or an
 arbitrarily large number.
 
 **Hard iteration ceiling** is a defence-in-depth guard independent of `max_items`. Even
@@ -117,15 +117,15 @@ wait for the resulting PR. This was not chosen because:
 
 ### Negative / Trade-offs
 - The 30-second inter-iteration sleep adds latency when processing multiple items.
-  A 3-item scheduled run takes at least 1 minute of sleep overhead. This is acceptable.
+  A 4-item scheduled run takes at least 1.5 minutes of sleep overhead. This is acceptable.
 - The hard ceiling of 10 iterations prevents processing large backlogs in a single run.
-  The scheduled trigger running weekdays at 07:00 UTC (3 items/day) compensates.
+  The scheduled trigger running weekdays at 07:00 UTC (4 items/day) compensates.
 - The workflow does not retry after a Copilot failure; it only tracks consecutive failures.
   A single isolated failure increments the counter but does not immediately abort.
 
 ### Neutral
 - `research-prompt.md` must be kept accurate. If it goes stale, the agent may behave
   incorrectly. This is explicitly noted in `AGENTS.md`.
-- The `timeout-minutes: 90` is generous relative to expected item processing time (≤30
+- The `timeout-minutes: 150` is generous relative to expected item processing time (≤30
   minutes per item). It is deliberately conservative to avoid false-positive timeouts on
   unusually complex research items.

--- a/docs-adr/0004-autonomous-research-loop.md
+++ b/docs-adr/0004-autonomous-research-loop.md
@@ -1,7 +1,7 @@
 # ADR-0004: Autonomous Research Loop Design and Safety Controls
 
 Date: 2026-03-02
-Status: accepted
+Status: accepted (safety control values superseded by [ADR-0012](0012-research-loop-safety-control-value-uplift.md))
 
 ## Context
 

--- a/docs-adr/0012-research-loop-safety-control-value-uplift.md
+++ b/docs-adr/0012-research-loop-safety-control-value-uplift.md
@@ -1,0 +1,69 @@
+# ADR-0012: Research Loop Safety Control Value Uplift
+
+Date: 2026-04-27
+Status: accepted
+Supersedes: safety control values in [ADR-0004](0004-autonomous-research-loop.md)
+
+## Context
+
+The research loop has been running successfully for several weeks. Two operational
+pressures prompted a review of the numeric safety-control values established in ADR-0004:
+
+1. **Throughput.** A 3-item scheduled cap processes 15 items per week. As the backlog grew,
+   this was too slow to keep pace with new additions. 4 items/day (20/week) better matches
+   the current ingest rate.
+
+2. **Timeout.** The 90-minute ceiling was set conservatively when item processing times were
+   unknown. Observed processing times are 20–45 minutes per item. A 4-item run with
+   worst-case items (4 × 45 min) exceeds 90 minutes, causing the job to be killed mid-item.
+   150 minutes provides headroom without being reckless.
+
+3. **Dispatch options.** The 1–5 dropdown was insufficient for manual catch-up runs after
+   holidays or rate-limit pauses. Extending to 1–7 matches the `HARD_MAX_ITERATIONS`
+   ceiling (10) with a comfortable margin.
+
+A secondary problem was discovered during this change: the Copilot agent running the
+research loop treats inline comments and description strings as authoritative spec. When
+code values diverge from those strings — even intentionally — the agent reverts the code
+to match the documentation. All documentation must therefore be updated atomically with
+the values, or the change will not persist.
+
+## Decision
+
+Update the three safety-control values and propagate them consistently to every location
+that references them:
+
+| Control | Old value | New value |
+|---|---|---|
+| `timeout-minutes` | 90 | 150 |
+| Scheduled `MAX_ITEMS` | 3 | 4 |
+| Dispatch `max_items` options | 1–5 | 1–7 |
+
+Files updated atomically in a single commit:
+- `.github/workflows/research-loop.yml` — code, inline comments, description string, and header comment block
+- `docs-adr/0004-autonomous-research-loop.md` — control table, prose, and trade-offs section
+- `.github/copilot-instructions.md` — schedule throughput and safety-controls summary
+- `tests/test_research_loop.py` — timeout assertion and upper-bound check
+
+The structural safety controls from ADR-0004 are unchanged: `HARD_MAX_ITERATIONS` (10),
+`FAILURE_THRESHOLD` (2), `INTER_ITERATION_SLEEP` (30 s), and the concurrency group
+remain as designed.
+
+## Consequences
+
+### Positive
+- 4-item scheduled runs process 20 items/week, keeping pace with backlog growth.
+- 150-minute timeout accommodates worst-case 4-item runs without false-positive kills.
+- 1–7 dispatch options support manual catch-up without requiring workflow edits.
+- Atomic documentation update prevents the Copilot agent from reverting the change.
+
+### Negative / Trade-offs
+- A 4-item scheduled run takes at least 2 minutes of inter-iteration sleep overhead (up from 1 minute).
+- The higher timeout means a genuinely hung job takes longer to be killed. The
+  `FAILURE_THRESHOLD` and `HARD_MAX_ITERATIONS` guards remain in place to catch this
+  before the timeout fires.
+- Dispatch options 6 and 7 approach `HARD_MAX_ITERATIONS` (10). If the hard ceiling is
+  ever lowered, the options list must be re-checked.
+
+### Neutral
+- The test suite enforces the new values; any future agent revert will fail CI.

--- a/docs-adr/README.md
+++ b/docs-adr/README.md
@@ -22,6 +22,7 @@ Format: [MADR (Markdown Architectural Decision Records)](https://adr.github.io/m
 | [0009](0009-consolidate-research-workflow.md) | Consolidate Research Workflow | Accepted | 2026-03-17 |
 | [0010](0010-github-pages-static-site.md) | GitHub Pages static site as research delivery channel | Accepted | 2026-03-23 |
 | [0011](0011-git-index-staging-in-cli-file-moves.md) | Git-index staging in CLI file-move commands | Accepted | 2026-03-29 |
+| [0012](0012-research-loop-safety-control-value-uplift.md) | Research loop safety control value uplift | Accepted | 2026-04-27 |
 
 ---
 

--- a/tests/test_research_loop.py
+++ b/tests/test_research_loop.py
@@ -91,7 +91,7 @@ def test_workflow_has_job_timeout() -> None:
     wf = _load_workflow()
     job = wf["jobs"]["research"]
     assert "timeout-minutes" in job, "Job must declare timeout-minutes"
-    assert job["timeout-minutes"] == 90, "Timeout must be exactly 90 minutes per ADR-0004"
+    assert job["timeout-minutes"] == 150, "Timeout must be exactly 150 minutes per ADR-0004"
 
 
 def test_workflow_has_concurrency_no_cancel() -> None:
@@ -160,12 +160,12 @@ def test_workflow_dispatch_max_items_is_choice_type() -> None:
 
 
 def test_workflow_dispatch_max_items_options_are_bounded() -> None:
-    """All max_items choices must be ≤ 5 (conservative upper bound)."""
+    """All max_items choices must be ≤ 7 (conservative upper bound)."""
     wf = _load_workflow()
     triggers = wf[True]
     options = triggers["workflow_dispatch"]["inputs"]["max_items"]["options"]
     for opt in options:
-        assert int(opt) <= 5, f"max_items option {opt} exceeds safe upper bound of 5"
+        assert int(opt) <= 7, f"max_items option {opt} exceeds safe upper bound of 7"
 
 
 def test_workflow_has_schedule_trigger() -> None:


### PR DESCRIPTION
Propagates the intended values consistently across all four locations so the
Copilot agent no longer sees a contradiction to revert:

- research-loop.yml: timeout-minutes 90→150, scheduled MAX_ITEMS 3→4,
  dispatch options extended to 1-7, description text updated to match
- ADR-0004: table, prose, and trade-offs section updated to reflect new values
- copilot-instructions.md: schedule throughput and safety-controls summary updated
- test_research_loop.py: timeout assertion 90→150, upper-bound check 5→7

https://claude.ai/code/session_01MeJpaWpDm5R7QbPUNgwSYh