### PR TITLE
backlog: build out synthesis framework and research corpus improvement backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -910,3 +910,99 @@ Version numbering convention:
 Blocked on W-0048 if Option A is chosen; can proceed independently under Option B.
 
 ---
+
+## W-0050
+
+status: open
+created: 2026-04-27
+updated: 2026-04-27
+
+### Outcome
+
+The research item picker enforces actual dependency ordering:
+
+- A `depends_on: []` frontmatter field is added to `Research/_template.md` — lists slugs of items that must be in `Research/completed/` before this item can be picked
+- `cmd_pick` in `src/research/cli.py` filters out any backlog item where one or more `depends_on` slugs are not present in `Research/completed/`
+- The `ResearchItem` dataclass is extended with `depends_on: list[str]`
+- The existing `blocks` field is retained as-is (it signals "I block these items" for priority sorting); `depends_on` is the inverse (it signals "I need these items done first")
+- Tests cover: item with satisfied dependencies is eligible; item with unsatisfied dependency is excluded; item with empty `depends_on` is always eligible
+- `copilot-instructions.md` updated to document both fields and their distinct semantics
+
+ADR required (picker behaviour change — items can now be excluded from picking, not just deprioritised).
+
+### Context
+
+The current picker uses the `blocks` field only as a priority sort tiebreaker — items with non-empty `blocks` lists are sorted higher, but items listed in `blocks` are not prevented from being picked before their prerequisites complete. Synthesis items that depend on multiple primary items being done first can be auto-started before their sources are available. The `depends_on` field provides actual gating: if prerequisites are not complete, the item is invisible to the picker.
+
+---
+
+## W-0051
+
+status: open
+created: 2026-04-27
+updated: 2026-04-27
+
+### Outcome
+
+A synthesis workflow is implemented end-to-end:
+
+- `Knowledge/` directory created at repo root for cross-item synthesis artifacts (distinct from `Research/completed/` primary research items)
+- `Knowledge/_template.md` — synthesis item template with sections: Cluster (list of source item slugs), Synthesis Question, Perspectives Considered, Cross-Item Findings, Contradictions and Tensions, Confidence Map, Open Questions
+- `synthesis-prompt.md` — synthesis agent prompt analogous to `research-prompt.md`; instructs the agent to read all source items via `filesystem` MCP, apply multi-perspective synthesis (not concatenation), identify contradictions across items, and populate `cites:` with source slugs
+- `.github/workflows/synthesis-loop.yml` — manual-trigger-only workflow (`workflow_dispatch`) accepting `source_items` (comma-separated slugs) and `synthesis_question` inputs; feeds `synthesis-prompt.md` to the Copilot CLI; never runs on schedule
+- Site (`build_site.py`) updated to render `Knowledge/` items alongside `Research/completed/` items
+- `item_type: synthesis` items in `Research/` are excluded from the autonomous research loop (enforced by W-0046 type field logic)
+
+Blocked on W-0046 (item_type field) and W-0044 (cites field). ADR required.
+
+### Context
+
+The current system produces primary research items (single-question answers) but has no mechanism for producing knowledge artifacts that integrate findings across multiple items. This is the systematic review equivalent — a distinct output type with its own methodology. Without it, the gap between accumulated research and usable knowledge cannot be closed. The synthesis workflow is the prerequisite for the authoring workflow (W-0052).
+
+---
+
+## W-0052
+
+status: open
+created: 2026-04-27
+updated: 2026-04-27
+
+### Outcome
+
+An authoring workflow is implemented for producing finished papers and framework documents:
+
+- `Outputs/papers/` and `Outputs/frameworks/` directories created at repo root
+- `Outputs/_paper-template.md` — paper template: Abstract, Introduction, Background (with cites to synthesis and primary items), Argument, Evidence, Implications, Conclusion, References
+- `Outputs/_framework-template.md` — framework template: Purpose, Scope, Conditions for Use, Decision Criteria or Maturity Levels, Worked Examples, Limitations, References
+- `authoring-prompt.md` — authoring agent prompt; instructs the agent to draw on specified synthesis and primary items, apply the `strategy-author` and `strategic-persuasion` skills, produce a finished draft, and populate the references section from `cites:` fields
+- `.github/workflows/authoring-loop.yml` — manual-trigger-only workflow accepting `output_type` (paper | framework), `title`, and `source_items` inputs
+- Site updated to render `Outputs/` items alongside research and knowledge items
+
+Blocked on W-0051 (synthesis workflow must exist before authoring draws on synthesis items). ADR required.
+
+### Context
+
+The research corpus and synthesis layer produce material that has direct value as publishable articles and practical frameworks. Currently no workflow exists to take that material and produce a finished artifact. The authoring workflow closes the last gap in the DIKW chain: data → information (primary research) → knowledge (synthesis) → wisdom (authored output). Papers and frameworks are the deliverable form that makes the research useful to audiences beyond the researcher.
+
+---
+
+## W-0053
+
+status: open
+created: 2026-04-27
+updated: 2026-04-27
+
+### Outcome
+
+A tag co-occurrence review workflow complements W-0043's canonical vocabulary with an evidence-driven discovery mechanism:
+
+- `scripts/tag_report.py` scans all `Research/completed/*.md` and `Research/backlog/*.md` and computes: tag frequency, tag co-occurrence matrix, near-duplicate candidates (Levenshtein distance ≤ 2 or prefix/suffix overlap ≥ 0.8), singleton tags (appear only once), and strong co-occurrence pairs (appear together in >80% of each other's occurrences — strong synonymy signal)
+- Output written to `state/tag_report.json` and human-readable `state/tag_report.md`
+- A workflow (`tag-review.yml`) runs monthly and on `workflow_dispatch`, commits the updated report, and opens a GitHub issue listing near-duplicate and singleton candidates for human review
+- The vocabulary in W-0043 is populated by reviewing the tag report output rather than by manual curation from scratch — the co-occurrence data drives what gets added to the canonical map
+
+### Context
+
+W-0043 defines the canonical tag vocabulary as the goal; W-0053 provides the evidence base for building and maintaining it without predefined assumptions. Running the co-occurrence report first means the vocabulary reflects what tags actually cluster in the corpus rather than what seems reasonable in advance. This is the difference between top-down taxonomy (W-0043 alone) and bottom-up taxonomy with human curation (W-0043 + W-0053 together). The intent is that W-0053 runs first, the human reviews the report, and the W-0043 vocabulary is populated from that evidence. W-0053 should be implemented and run before W-0043 is executed.
+
+---

--- a/Research/backlog/2026-04-26-vendor-platform-governance-constraints-compensating-controls.md
+++ b/Research/backlog/2026-04-26-vendor-platform-governance-constraints-compensating-controls.md
@@ -3,7 +3,7 @@ title: "What constraints do vendor platforms impose on governance, and how shoul
 added: 2026-04-26T10:11:11+00:00
 status: backlog
 priority: medium
-blocks: [2026-04-26-ai-agent-control-plane-architecture-enterprise]
+blocks: []
 tags: [vendor-governance, low-code, ai-platforms, compensating-controls, enterprise-governance, platform-limitations, multi-platform, microsoft-power-platform, salesforce]
 started: ~
 completed: ~

--- a/Research/backlog/2026-04-27-academic-post-publication-amendment-practices.md
+++ b/Research/backlog/2026-04-27-academic-post-publication-amendment-practices.md
@@ -1,0 +1,158 @@
+---
+title: "How do academic and scientific publishing systems handle post-publication corrections, amendments, retractions, and commentary, and what is the minimal viable analogue for a versioned git-based research corpus?"
+added: 2026-04-27T06:20:00+00:00
+status: backlog
+priority: high
+blocks: []
+tags: [academic-publishing, post-publication, corrections, retractions, amendments, rebuttal, immutability, versioning, knowledge-management, research-methodology, doi, corrigendum, erratum]
+started: ~
+completed: ~
+output: [knowledge, backlog-item]
+---
+
+# How do academic and scientific publishing systems handle post-publication corrections, amendments, retractions, and commentary, and what is the minimal viable analogue for a versioned git-based research corpus?
+
+## Research Question
+
+How do established academic and scientific publishing systems (journal publishers, preprint servers, living review platforms) handle post-publication corrections, amendments, retractions, and formal commentary — and what is the minimal viable analogue for a versioned, git-based private research corpus where completed items should be treated as immutable records with narrow, explicitly defined exceptions?
+
+## Scope
+
+**In scope:**
+- The four main post-publication update mechanisms in academic publishing: corrigenda/errata (corrections), retractions (invalidations), comments and replies (formal challenges and responses), and living reviews (continuously updated systematic reviews)
+- The structural conventions used: how corrections are physically attached to the original record, what metadata fields change, what signals readers (and indexing systems) receive
+- Preprint server versioning (arXiv, bioRxiv): how version history is preserved and surfaced, what constitutes a "new version" vs a "new paper"
+- The distinction between acceptable silent corrections (typos, broken URLs) and corrections that require a formal record (factual claim changes, methodology changes, finding reversals)
+- Cochrane Reviews as the gold standard for living systematic reviews: update protocol, versioning, what triggers an update vs a new review
+- The practical minimum: what the smallest viable amendment mechanism looks like for a git-backed, Markdown-based corpus — specifically, what must be structured data (frontmatter fields) vs what can remain prose
+
+**Out of scope:**
+- Legal aspects of retractions (libel, misconduct investigations)
+- Full systematic review methodology (PRISMA, GRADE) — only the update/amendment protocol is in scope
+- Publisher-specific proprietary systems (CrossRef mechanics, DOI redirect infrastructure)
+- Any mechanism requiring a database or external service — the target implementation is pure git + Markdown
+
+**Constraints:**
+- Primary sources preferred: publisher guidelines, COPE (Committee on Publication Ethics) guidelines, actual retraction notices, arXiv versioning documentation
+- The output must include a specific recommendation for the amendment frontmatter schema and amendment item template for this repo (a direct input to W-0038 in BACKLOG.md)
+
+## Context
+
+This item directly informs the implementation of the research immutability protocol (repo improvement W-0038). The design principle is that completed research items should not be silently edited — the record of what was believed at a point in time is itself valuable, and silent edits destroy provenance. Academic publishing has solved this problem at scale. Before designing a bespoke mechanism, it is worth understanding what the established patterns are, why they are structured as they are, and what the minimal viable version looks like for a much smaller, private, git-backed corpus. The output of this item feeds directly into W-0038 scoping.
+
+## Approach
+
+1. **Corrigendum/erratum mechanics**: Survey 3–5 major journal publishers (Nature, Science, PLOS ONE, BMJ, IEEE) for their published correction policies. What triggers a corrigendum vs an erratum? What is physically published? How is it linked to the original? What metadata changes?
+2. **Retraction mechanics**: Survey the Retraction Watch database and COPE retraction guidelines. What constitutes a retraction vs a correction? What is the minimum retraction notice? Is the original removed or marked? What fields change?
+3. **Comment and reply mechanics**: Survey how journals handle formal post-publication commentary (letters to the editor, technical comments, invited replies). What is the structural relationship between comment and original? How are they indexed?
+4. **Living reviews**: Survey Cochrane Reviews update protocol and at least one other living review format (e.g., Living Evidence Network). What triggers an update? What is preserved from prior versions? What is the versioning convention?
+5. **Preprint versioning**: Survey arXiv and bioRxiv versioning. What is preserved between versions? What triggers a new version? How are citations to earlier versions handled?
+6. **Minimal viable analogue**: Based on the above, define the minimal set of mechanisms needed for a git-backed Markdown corpus. Specifically: what frontmatter fields are needed, what file naming convention for amendment items, what the amendment item template must contain, and what the three acceptable silent-edit exceptions are (broken URLs, tag updates, citation URL fixes).
+7. **Synthesis**: Produce a schema recommendation and amendment item template as the primary output — a direct input to W-0038.
+
+## Sources
+
+- [ ] [COPE (Committee on Publication Ethics) — Retraction Guidelines](https://publicationethics.org/retraction-guidelines) — primary source for retraction standards and triggers
+- [ ] [COPE — Correction Guidelines](https://publicationethics.org/cope-guidelines-retracting-articles) — primary source for correction standards
+- [ ] [Retraction Watch](https://retractionwatch.com/) — empirical data on retraction patterns and notices
+- [ ] [arXiv — Submission and revision help](https://info.arxiv.org/help/submit/index.html) — versioning mechanics for preprint server
+- [ ] [bioRxiv — About versioning](https://www.biorxiv.org/content/about-biorxiv) — versioning mechanics for life sciences preprint server
+- [ ] [Cochrane — Updating Cochrane Reviews policy](https://www.cochranelibrary.com/about/about-cochrane-reviews) — gold standard for living systematic review update protocol
+- [ ] [Nature — Corrections and retractions policy](https://www.nature.com/nature-portfolio/editorial-policies/corrections-and-retractions) — major journal primary policy
+- [ ] [PLOS ONE — Corrections policy](https://journals.plos.org/plosone/s/corrections-and-retractions) — open-access journal primary policy
+- [ ] [BMJ — Corrections policy](https://www.bmj.com/about-bmj/resources-authors/forms-policies-and-checklists/corrections) — medical journal primary policy
+
+---
+
+## Research Skill Output
+
+*(Full output from running the research skill — retained verbatim in the completed item. §§0–5 are the investigation; §6 seeds the Findings section below.)*
+
+### §0 Initialise
+
+-
+
+### §1 Question Decomposition
+
+-
+
+### §2 Investigation
+
+-
+
+### §3 Reasoning
+
+-
+
+### §4 Consistency Check
+
+-
+
+### §5 Depth and Breadth Expansion
+
+-
+
+### §6 Synthesis
+
+*(This section seeds the Findings below.)*
+
+**Executive summary:**
+
+**Key findings:**
+
+**Evidence map:**
+
+**Assumptions:**
+
+**Analysis:**
+
+**Risks, gaps, uncertainties:**
+
+**Open questions:**
+
+### §7 Recursive Review
+
+-
+
+---
+
+## Findings
+
+*(Populated from §6 Synthesis above.)*
+
+### Executive Summary
+
+### Key Findings
+
+1.
+2.
+
+### Evidence Map
+
+| Claim | Source | Confidence | Notes |
+|---|---|---|---|
+| | | high / medium / low | |
+
+### Assumptions
+
+- **Assumption:** ... **Justification:** ...
+
+### Analysis
+
+### Risks, Gaps, and Uncertainties
+
+-
+
+### Open Questions
+
+-
+
+---
+
+## Output
+
+*(Fill in when completing — what was produced as a result of this research?)*
+
+- Type: knowledge, backlog-item
+- Description: Amendment schema recommendation and item template (feeds W-0038)
+- Links:

--- a/progress/2026-04-27-research-synthesis-framework-backlog-build.md
+++ b/progress/2026-04-27-research-synthesis-framework-backlog-build.md
@@ -1,0 +1,50 @@
+# 2026-04-27 — Research synthesis framework: backlog build
+
+**Session branch:** `claude/research-synthesis-framework-NZwVX`
+
+## Completed
+
+- Discussion and analysis of academic journal practices for updating, cross-referencing, and tagging (how corrigenda, retractions, controlled vocabulary, systematic reviews, and citation graphs work)
+- Survey of open-source autonomous research projects (GPT Researcher, STORM, Open Deep Research, smolagents, LangGraph, Knowledge Explorer, Letta) — key patterns identified for adoption
+- Architecture decisions for the four goals (gap follow-up, synthesis, authoring, frameworks)
+- Evaluated existing research backlog (14 items): strong overall, two issues found
+  - `vendor-platform-governance-constraints-compensating-controls`: stale `blocks` reference to already-completed item → fixed (cleared to `[]`)
+  - Agentic-ai-foundational-conditions synthesis item: all 5 prerequisites already in `completed/` — ready to pick now but may be delayed by PBAC cluster's non-empty `blocks` lists in picker sort
+- Confirmed picker bug: `blocks` field only influences sort order, does not gate picking — items can be picked before their dependencies complete
+- Added W-0038 through W-0050 to `BACKLOG.md` (13 new repo improvement items)
+- Created `Research/backlog/2026-04-27-academic-post-publication-amendment-practices.md` (high priority, informs W-0038)
+
+## New BACKLOG.md items summary
+
+| Item | Purpose |
+|---|---|
+| W-0038 | Research immutability — amendment + rebuttal mechanism |
+| W-0039 | Gap register — structured Open Questions extraction |
+| W-0040 | Cross-reference frontmatter (cites, related) |
+| W-0041 | Supersession field (superseded_by) |
+| W-0042 | Item type field (primary-research / synthesis / paper / framework) |
+| W-0043 | Tag co-occurrence review workflow (organic normalization, no predefined taxonomy) |
+| W-0044 | Evidence confidence field |
+| W-0045 | Synthesis workflow + Knowledge/ directory |
+| W-0046 | Authoring workflow + Outputs/ directories |
+| W-0047 | STORM-style multi-perspective questioning in research prompt |
+| W-0048 | Memory MCP integration in research workflow |
+| W-0049 | arXiv claim verification step in research prompt |
+| W-0050 | Dependency enforcement in picker (depends_on field) |
+
+## Key design decisions
+
+- **Tags**: NOT a predefined taxonomy. Organic/emergent vocabulary with a post-hoc co-occurrence review that surfaces synonym candidates for human curation (W-0043)
+- **Immutability**: Completed items are immutable with three narrow silent-edit exceptions (broken URLs, tag updates, citation URL fixes). All other changes via amendment items or supersession (W-0038)
+- **Synthesis**: Separate workflow, separate directory (Knowledge/), separate item type — not conflated with primary research (W-0042, W-0045)
+- **Dependency enforcement**: New `depends_on` field that actually gates picking, distinct from `blocks` which remains as priority signal (W-0050)
+- **Memory MCP**: Already configured but unused — integrate into research workflow for cross-session accumulation (W-0048)
+
+## Mini-Retro
+
+1. **Did the process work?** Yes — the discussion → research → backlog sequence produced well-scoped items grounded in the actual state of the repo.
+2. **What slowed down or went wrong?** Skills submodule not initialised (empty). Applied backlog-manager conventions from copilot-instructions.md directly.
+3. **What single change would prevent this next time?** W-0036 (devcontainer setup) would ensure submodule is initialised automatically.
+4. **Is this a pattern?** Yes — submodule initialisation is a recurring gap in cloud agent environments (see Known Recurring Patterns table).
+5. **Does any documentation need updating?** No — all design decisions are captured in the new BACKLOG.md items themselves.
+6. **Do the default instructions need updating?** The picker's `blocks` field semantics gap (W-0050) is now documented in BACKLOG.md. The copilot-instructions.md does not need updating until W-0050 is implemented.


### PR DESCRIPTION
Adds W-0038 through W-0050 to BACKLOG.md covering: research immutability
protocol, gap register, cross-reference frontmatter, supersession, item type
field, tag co-occurrence review, evidence confidence, synthesis workflow,
authoring workflow, STORM-style multi-perspective questioning, memory MCP
integration, arXiv citation verification, and dependency enforcement in picker.

Also adds research backlog item on academic post-publication amendment
practices (informs W-0038) and fixes a stale blocks reference in the
vendor-platform governance item (ai-agent-control-plane-architecture was
already in completed/).

https://claude.ai/code/session_01T1UpZifvwra68UzRvfV9BP